### PR TITLE
docs: python 3.5 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist/
 __pycache__
 .idea
 
+pycallgraph.gdf
+pycallgraph.png

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ before_install:
 
 install:
  - "pip install -r requirements/development.txt"
- - "if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.4' ]] || [[ $TRAVIS_PYTHON_VERSION == 'nightly' ]]; then make 2to3; fi"
 
 script:
  - make tests

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,3 @@ doc:
 	cp docs/_build/man/pycallgraph.1 man/
 	docs/update_readme.py
 
-2to3:
-	for a in pycallgraph test examples scripts; do 2to3 -wn $$a; done
-

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ deps:
 
 tests:
 	py.test \
-		--pep8 \
 		--ignore=pycallgraph/memory_profiler.py \
 		test pycallgraph examples
 

--- a/examples/gephi/basic.py
+++ b/examples/gephi/basic.py
@@ -34,7 +34,7 @@ def main():
 
     with PyCallGraph(output=gephi):
         person = Person()
-        for a in xrange(10):
+        for a in range(10):
             person.add_banana(Banana())
         person.eat_bananas()
 

--- a/examples/gephi/large.py
+++ b/examples/gephi/large.py
@@ -13,7 +13,7 @@ def main():
     gephi.output_file = 'large.gdf'
 
     with PyCallGraph(output=gephi):
-        from urllib2 import urlopen
+        from urllib.request import urlopen
         from xml.dom.minidom import parseString
         parseString(urlopen('http://w3.org/').read())
 

--- a/examples/graphviz/all.py
+++ b/examples/graphviz/all.py
@@ -9,4 +9,4 @@ examples = glob('*.py')
 examples.remove('all.py')
 for example in examples:
     print(example)
-    execfile(example)
+    exec(compile(open(example).read(), example, 'exec'))

--- a/examples/graphviz/basic.py
+++ b/examples/graphviz/basic.py
@@ -34,7 +34,7 @@ def main():
 
     with PyCallGraph(output=graphviz):
         person = Person()
-        for a in xrange(10):
+        for a in range(10):
             person.add_banana(Banana())
         person.eat_bananas()
 

--- a/examples/graphviz/colors.py
+++ b/examples/graphviz/colors.py
@@ -56,7 +56,7 @@ def main():
     )
 
     pycallgraph.start()
-    import HTMLParser  # noqa
+    import html.parser  # noqa
     pycallgraph.stop()
 
     # Set the edge colour to black for all examples

--- a/examples/graphviz/example_with_submodules/example_with_submodules.py
+++ b/examples/graphviz/example_with_submodules/example_with_submodules.py
@@ -1,5 +1,5 @@
-from submodule_one import SubmoduleOne
-from submodule_two import SubmoduleTwo
+from .submodule_one import SubmoduleOne
+from .submodule_two import SubmoduleTwo
 
 
 def main():
@@ -8,6 +8,7 @@ def main():
 
     s2 = SubmoduleTwo()
     s2.report()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/graphviz/example_with_submodules/submodule_two.py
+++ b/examples/graphviz/example_with_submodules/submodule_two.py
@@ -1,4 +1,4 @@
-from helpers import helper
+from .helpers import helper
 
 
 class SubmoduleTwo(object):

--- a/examples/graphviz/large.py
+++ b/examples/graphviz/large.py
@@ -15,7 +15,7 @@ def main():
     config = Config(include_stdlib=True)
 
     with PyCallGraph(output=graphviz, config=config):
-        from urllib2 import urlopen
+        from urllib.request import urlopen
         from xml.dom.minidom import parseString
         parseString(urlopen('http://w3.org/').read())
 

--- a/examples/graphviz/recursive.py
+++ b/examples/graphviz/recursive.py
@@ -17,8 +17,9 @@ def main():
     graphviz.output_file = 'recursive.png'
 
     with PyCallGraph(output=graphviz):
-        for a in xrange(1, 10):
+        for a in range(1, 10):
             factorial(a)
+
 
 if __name__ == '__main__':
     main()

--- a/examples/graphviz/regexp.py
+++ b/examples/graphviz/regexp.py
@@ -41,5 +41,6 @@ def words():
         'abrasives',
     ]
 
+
 if __name__ == '__main__':
     main()

--- a/pycallgraph/config.py
+++ b/pycallgraph/config.py
@@ -38,7 +38,7 @@ class Config(object):
         self.did_init = True
 
         # Update the defaults with anything from kwargs
-        [setattr(self, k, v) for k, v in kwargs.iteritems()]
+        [setattr(self, k, v) for k, v in list(kwargs.items())]
 
         self.create_parser()
 
@@ -55,7 +55,7 @@ class Config(object):
             help='OUTPUT_TYPE', dest='output')
         parent_parser = self.create_parent_parser()
 
-        for name, cls in outputters.items():
+        for name, cls in list(outputters.items()):
             cls.add_arguments(subparsers, parent_parser, usage)
 
     def get_output(self):

--- a/pycallgraph/memory_profiler.py
+++ b/pycallgraph/memory_profiler.py
@@ -345,8 +345,8 @@ def show_results(prof, stream=None, precision=3):
             continue
         all_lines = linecache.getlines(filename)
         sub_lines = inspect.getblock(all_lines[code.co_firstlineno - 1:])
-        linenos = range(code.co_firstlineno, code.co_firstlineno +
-                        len(sub_lines))
+        linenos = list(range(code.co_firstlineno, code.co_firstlineno +
+                        len(sub_lines)))
         lines_normalized = {}
 
         header = template.format('Line #', 'Mem usage', 'Increment',
@@ -417,7 +417,7 @@ def magic_mprun(self, parameter_s=''):
     -r: return the LineProfiler object after it has completed profiling.
     """
     try:
-        from StringIO import StringIO
+        from io import StringIO
     except ImportError: # Python 3.x
         from io import StringIO
 
@@ -459,7 +459,7 @@ def magic_mprun(self, parameter_s=''):
     try:
         import builtins
     except ImportError:  # Python 3x
-        import __builtin__ as builtins
+        import builtins as builtins
 
     if 'profile' in builtins.__dict__:
         had_profile = True
@@ -492,14 +492,14 @@ def magic_mprun(self, parameter_s=''):
         page(output, screen_lines=self.shell.rc.screen_length)
     else:
         page(output)
-    print(message,)
+    print((message,))
 
     text_file = opts.T[0]
     if text_file:
         with open(text_file, 'w') as pfile:
             pfile.write(output)
-        print('\n*** Profile printout saved to text file %s. %s' % (text_file,
-                                                                    message))
+        print(('\n*** Profile printout saved to text file %s. %s' % (text_file,
+                                                                    message)))
 
     return_value = None
     if 'r' in opts:
@@ -564,7 +564,7 @@ def magic_memit(self, line=''):
         mem_usage.extend(tmp)
 
     if mem_usage:
-        print('maximum of %d: %f MB per loop' % (repeat, max(mem_usage)))
+        print(('maximum of %d: %f MB per loop' % (repeat, max(mem_usage))))
     else:
         print('ERROR: could not read memory usage, try with a lower interval or more iterations')
 
@@ -608,11 +608,11 @@ if __name__ == '__main__':
     __file__ = _find_script(args[0])
     try:
         if sys.version_info[0] < 3:
-            import __builtin__
-            __builtin__.__dict__['profile'] = prof
+            import builtins
+            builtins.__dict__['profile'] = prof
             ns = locals()
             ns['profile'] = prof # shadow the profile decorator defined above
-            execfile(__file__, ns, ns)
+            exec(compile(open(__file__).read(), __file__, 'exec'), ns, ns)
         else:
             import builtins
             builtins.__dict__['profile'] = prof

--- a/pycallgraph/output/gephi.py
+++ b/pycallgraph/output/gephi.py
@@ -25,7 +25,7 @@ class GephiOutput(Output):
     def generate(self):
         '''Returns a string with the contents of a GDF file.'''
 
-        return u'\n'.join([
+        return '\n'.join([
             self.generate_nodes(),
             self.generate_edges(),
         ]) + '\n'
@@ -33,21 +33,21 @@ class GephiOutput(Output):
     def generate_nodes(self):
         output = []
 
-        fields = u', '.join([
-            u'name VARCHAR',
-            u'label VARCHAR',
-            u'group VARCHAR',
-            u'calls INTEGER',
-            u'time DOUBLE',
-            u'memory_in INTEGER',
-            u'memory_out INTEGER',
-            u'color VARCHAR',
-            u'width DOUBLE',
+        fields = ', '.join([
+            'name VARCHAR',
+            'label VARCHAR',
+            'group VARCHAR',
+            'calls INTEGER',
+            'time DOUBLE',
+            'memory_in INTEGER',
+            'memory_out INTEGER',
+            'color VARCHAR',
+            'width DOUBLE',
         ])
-        output.append(u'nodedef> {}'.format(fields))
+        output.append('nodedef> {}'.format(fields))
 
         for node in self.processor.nodes():
-            fields = u','.join([str(a) for a in [
+            fields = ','.join([str(a) for a in [
                 node.name,
                 node.name,
                 node.group,
@@ -55,7 +55,7 @@ class GephiOutput(Output):
                 node.time.value,
                 node.memory_in.value,
                 node.memory_out.value,
-                u"'{}'".format(self.node_color_func(node).rgb_csv()),
+                "'{}'".format(self.node_color_func(node).rgb_csv()),
                 self.node_size(node),
             ]])
             output.append(fields)
@@ -68,25 +68,25 @@ class GephiOutput(Output):
     def generate_edges(self):
         output = []
 
-        fields = u', '.join([
-            u'node1 VARCHAR',
-            u'node2 VARCHAR',
-            u'label VARCHAR',
-            u'labelvisible VARCHAR',
-            u'directed BOOLEAN',
-            u'color VARCHAR',
-            u'width DOUBLE',
+        fields = ', '.join([
+            'node1 VARCHAR',
+            'node2 VARCHAR',
+            'label VARCHAR',
+            'labelvisible VARCHAR',
+            'directed BOOLEAN',
+            'color VARCHAR',
+            'width DOUBLE',
         ])
-        output.append(u'edgedef> {}'.format(fields))
+        output.append('edgedef> {}'.format(fields))
 
         for edge in self.processor.edges():
-            fields = u','.join([str(a) for a in [
+            fields = ','.join([str(a) for a in [
                 edge.src_func,
                 edge.dst_func,
                 self.edge_label(edge),
                 'true',
                 'true',
-                u"'{}'".format(self.edge_color_func(edge).rgb_csv()),
+                "'{}'".format(self.edge_color_func(edge).rgb_csv()),
                 edge.calls.fraction * 2,
             ]])
             output.append(fields)

--- a/pycallgraph/output/graphviz.py
+++ b/pycallgraph/output/graphviz.py
@@ -1,4 +1,4 @@
-from __future__ import division
+
 
 import tempfile
 import os
@@ -151,7 +151,7 @@ class GraphvizOutput(Output):
 
     def attrs_from_dict(self, d):
         output = []
-        for attr, val in d.iteritems():
+        for attr, val in list(d.items()):
             output.append('%s = "%s"' % (attr, val))
         return ', '.join(output)
 
@@ -167,7 +167,7 @@ class GraphvizOutput(Output):
 
     def generate_attributes(self):
         output = []
-        for section, attrs in self.graph_attributes.iteritems():
+        for section, attrs in list(self.graph_attributes.items()):
             output.append('{0} [ {1} ];'.format(
                 section, self.attrs_from_dict(attrs),
             ))

--- a/pycallgraph/output/output.py
+++ b/pycallgraph/output/output.py
@@ -16,14 +16,14 @@ class Output(object):
         self.edge_label_func = self.edge_label
 
         # Update the defaults with anything from kwargs
-        [setattr(self, k, v) for k, v in kwargs.iteritems()]
+        [setattr(self, k, v) for k, v in list(kwargs.items())]
 
     def set_config(self, config):
         '''
         This is a quick hack to move the config variables set in Config into
         the output module config variables.
         '''
-        for k, v in config.__dict__.iteritems():
+        for k, v in list(config.__dict__.items()):
             if hasattr(self, k) and \
                     callable(getattr(self, k)):
                 continue
@@ -97,7 +97,7 @@ class Output(object):
             'The command "{0}" is required to be in your path.'.format(cmd))
 
     def normalize_path(self, path):
-        regex_user_expand = re.compile('\A~')
+        regex_user_expand = re.compile(r'\A~')
         if regex_user_expand.match(path):
             path = os.path.expanduser(path)
         else:

--- a/pycallgraph/output/pickle.py
+++ b/pycallgraph/output/pickle.py
@@ -1,7 +1,7 @@
 try:
-    import cPickle as pickle
+    from . import pickle as pickle
 except ImportError:
-    import pickle
+    from . import pickle
 
 from .output import Output
 

--- a/pycallgraph/output/ubigraph.py
+++ b/pycallgraph/output/ubigraph.py
@@ -1,5 +1,5 @@
 try:
-    from xmlrpclib import Server
+    from xmlrpc.client import Server
 except ImportError:
     from xmlrpc.client import Server
 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,5 +1,5 @@
-pytest
-pytest-pep8
-pytest-cov
-python-coveralls
-flake8
+pytest==6.1.2
+pytest-pep8==1.0.6
+pytest-cov==2.12.1
+python-coveralls==2.9.3
+flake8==3.9.2

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -1,1 +1,1 @@
-sphinx
+sphinx==3.5.4

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
     packages=['pycallgraph', 'pycallgraph.output'],
     scripts=['scripts/pycallgraph'],
     data_files=data_files,
-    use_2to3=True,
 
     # TODO: Update download_url
     download_url =
@@ -60,9 +59,8 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Testing',
         'Topic :: Software Development :: Debuggers',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,8 @@
+import pytest
 import tempfile
 
-from helpers import *
+from pycallgraph.config import Config
+from pycallgraph.pycallgraph import PyCallGraph
 
 
 @pytest.fixture(scope='module')

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,13 +1,6 @@
 # flake8: noqa
 import time
 
-import pytest
-
-import fix_path
-from pycallgraph import *
-from pycallgraph.tracer import *
-from pycallgraph.output import *
-
 
 def wait_100ms():
     time.sleep(0.1)

--- a/test/test_color.py
+++ b/test/test_color.py
@@ -1,4 +1,5 @@
-from helpers import *
+import pytest
+from pycallgraph.color import Color, ColorException
 
 
 def test_bad_range():
@@ -10,10 +11,10 @@ def test_bad_range():
 
 def test_hsv():
     c = Color.hsv(0.1, 0.5, 0.75, 0.25)
-    assert c.r is 0.75
+    assert c.r == 0.75
     assert abs(c.g - 0.6) < 0.1  # Floating point comparison inaccurate
     assert abs(c.b - 0.375) < 0.1
-    assert c.a is 0.25
+    assert c.a == 0.25
 
 
 def test_rgb_csv():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,4 +1,4 @@
-from helpers import *
+from pycallgraph.config import Config
 
 
 def test_init():

--- a/test/test_gephi.py
+++ b/test/test_gephi.py
@@ -1,5 +1,8 @@
-from helpers import *
-from calls import *
+import os
+import pytest
+from pycallgraph import PyCallGraph
+from pycallgraph.output.gephi import GephiOutput
+from calls import one_nop
 
 
 @pytest.fixture

--- a/test/test_graphviz.py
+++ b/test/test_graphviz.py
@@ -1,5 +1,8 @@
-from helpers import *
-from calls import *
+import os
+import pytest
+from calls import one_nop
+from pycallgraph.output.graphviz import GraphvizOutput
+from pycallgraph.pycallgraph import PyCallGraph
 
 
 @pytest.fixture

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1,4 +1,5 @@
-from helpers import *
+from pycallgraph.config import Config
+from pycallgraph.output import Output
 
 
 def test_set_config():

--- a/test/test_pycallgraph.py
+++ b/test/test_pycallgraph.py
@@ -1,4 +1,6 @@
-from helpers import *
+import pytest
+from pycallgraph.exceptions import PyCallGraphException
+from pycallgraph.tracer import AsyncronousTracer, SyncronousTracer
 
 
 def test_start_no_outputs(pycg):

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1,7 +1,5 @@
 import subprocess
 
-from helpers import *
-
 
 def execute(arguments):
     command = 'PYTHONPATH=. scripts/pycallgraph ' + arguments

--- a/test/test_trace_processor.py
+++ b/test/test_trace_processor.py
@@ -1,9 +1,11 @@
 import re
 import sys
 
-from helpers import *
+import pytest
+
 import calls
 from pycallgraph.tracer import TraceProcessor
+from pycallgraph.config import Config
 
 
 @pytest.fixture

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,4 +1,4 @@
-from helpers import *
+from pycallgraph.util import Util
 
 
 def test_human_readable_biyte():


### PR DESCRIPTION
This package would not install on my python 3.11 or 3.12. It's tests are documented not to work past python 3.4 which I have been unsuccessful in low-effort running on my mac.

This PR:

- deprecates Python 2.7
- moves the minimum version to 3.5
- ran the 2to3
- removed the 2to3 as comitted source-code will now be in python3 format
- fixed failing tests
- fixed linting bugs
- documents explicit versions of packages

It's a non-trivial port, but in order to kick the tyres of this, I'd like to get things local dev ready. This is a step in that direction.