### PR TITLE
refactor: use standard_lib argument to get_python_lib

### DIFF
--- a/pycallgraph/tracer.py
+++ b/pycallgraph/tracer.py
@@ -104,7 +104,7 @@ class TraceProcessor(Thread):
 
     def init_libpath(self):
         self.lib_paths = [
-            sysconfig.get_python_lib().lower(),
+            sysconfig.get_python_lib(standard_lib=True).lower(),
             sysconfig.get_config_var('LIBDEST').lower(),
         ]
 


### PR DESCRIPTION
Reading through docs and following code, it seems there is a `standard_lib` boolean argument, which strips site-packages. While I've not been able to replicate needing that, it was present in the original code and may represent an upgrade path blocker for folks.

Lets keep that but allow `distutils` to own that, rather than manually stripping path that has been built-up in the `get_python_lib` call