### PR TITLE
ci: rename release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Release
 
 on:
   release:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Click on the images below to see a larger version and the source code that gener
 
 ## Project Status
 
-The latest version is **2.0.4** which was released on 2024-03-31, and is a backwards incompatible from the previous release, dropped 2.7 support.
+The latest version is **2.0.5** which was released on 2024-03-31, and is a backwards incompatible from the previous release, dropped 2.7 support.
 The latest version has been tested running on Python versions 3.5 - 3.12
 
 The [project lives on GitHub](https://github.com/lewiscowles1986/py-call-graph/#python-call-graph), where you can [report issues](https://github.com/lewiscowles1986/py-call-graph/issues), contribute to the project by [forking the project](https://help.github.com/articles/fork-a-repo) then creating a [pull request](https://help.github.com/articles/using-pull-requests), or just [browse the source code](https://github.com/lewiscowles1986/py-call-graph/).

--- a/pycallgraph/metadata.py
+++ b/pycallgraph/metadata.py
@@ -1,6 +1,6 @@
 # A different file to pycallgraph.py because of circular import problem
 
-__version__ = '2.0.4'
+__version__ = '2.0.5'
 __copyright__ = 'Copyright Gerald Kaszuba 2007-2013'
 __license__ = 'GPLv2'
 __author__ = 'Gerald Kaszuba'


### PR DESCRIPTION
Just noticed in my haste I'd called the release job CI

This won't affect functionality