### PR TITLE
refactor: python 3.12 deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   setup:
     strategy:
       matrix:
-        python_version: ["3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.19", "3.10.14", "3.11.8", "3.12.2"]
+        python_version: ["3.8.18", "3.9.19", "3.10.14", "3.11.8", "3.12.2"]
       fail-fast: false
     name: setup - Python ${{ matrix.python_version }}
     runs-on: ubuntu-20.04
@@ -43,7 +43,7 @@ jobs:
       - setup
     strategy:
       matrix:
-        python_version: ["3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.19", "3.10.14", "3.11.8", "3.12.2"]
+        python_version: ["3.8.18", "3.9.19", "3.10.14", "3.11.8", "3.12.2"]
       fail-fast: false
     name: Lint - Python ${{ matrix.python_version }}
     runs-on: ubuntu-20.04
@@ -69,7 +69,7 @@ jobs:
       - setup
     strategy:
       matrix:
-        python_version: ["3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.19", "3.10.14", "3.11.8", "3.12.2"]
+        python_version: ["3.8.18", "3.9.19", "3.10.14", "3.11.8", "3.12.2"]
       fail-fast: false
     name: Test - Python ${{ matrix.python_version }}
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,15 @@ jobs:
       matrix:
         python_version: ["3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.19", "3.10.14", "3.11.8", "3.12.2"]
       fail-fast: false
-    name: setup - Python ${{ matrix.python-version }}
+    name: setup - Python ${{ matrix.python_version }}
     runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python_version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python_version }}
         cache: 'pip'
         cache-dependency-path: |
           requirements/development.txt
@@ -45,14 +45,14 @@ jobs:
       matrix:
         python_version: ["3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.19", "3.10.14", "3.11.8", "3.12.2"]
       fail-fast: false
-    name: Lint - Python ${{ matrix.python-version }}
+    name: Lint - Python ${{ matrix.python_version }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python_version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python_version }}
         cache: 'pip'
         cache-dependency-path: |
           requirements/development.txt
@@ -71,14 +71,14 @@ jobs:
       matrix:
         python_version: ["3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.19", "3.10.14", "3.11.8", "3.12.2"]
       fail-fast: false
-    name: Test - Python ${{ matrix.python-version }}
+    name: Test - Python ${{ matrix.python_version }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python_version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python_version }}
         cache: 'pip'
         cache-dependency-path: |
           requirements/development.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,5 +95,5 @@ jobs:
           test pycallgraph examples
     - name: Collect coverage
       run: |
-        coverage run --source pycallgraph,scripts -m py.test
+        coverage run --source pycallgraph,scripts -m pytest
         coverage report -m

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ __pycache__
 
 pycallgraph.gdf
 pycallgraph.png
+*env/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ tests:
 		--ignore=pycallgraph/memory_profiler.py \
 		test pycallgraph examples
 
-	coverage run --source pycallgraph,scripts -m py.test
+	coverage run --source pycallgraph,scripts -m pytest
 	coverage report -m
 
 	flake8 --exclude=__init__.py,memory_profiler.py pycallgraph

--- a/pycallgraph/decorators.py
+++ b/pycallgraph/decorators.py
@@ -7,7 +7,7 @@ def trace(output=None, config=None):
     def inner(func):
         @functools.wraps(func)
         def exec_func(*args, **kw_args):
-            with(PyCallGraph(output, config)):
+            with PyCallGraph(output, config):
                 return func(*args, **kw_args)
 
         return exec_func

--- a/pycallgraph/memory_profiler.py
+++ b/pycallgraph/memory_profiler.py
@@ -422,10 +422,10 @@ def magic_mprun(self, parameter_s=''):
         from io import StringIO
 
     # Local imports to avoid hard dependency.
-    from distutils.version import LooseVersion
+    from packaging.version import parse
     import IPython
-    ipython_version = LooseVersion(IPython.__version__)
-    if ipython_version < '0.11':
+    ipython_version = parse(IPython.__version__)
+    if ipython_version < parse('0.11'):
         from IPython.genutils import page
         from IPython.ipstruct import Struct
         from IPython.ipapi import UsageError

--- a/pycallgraph/output/output.py
+++ b/pycallgraph/output/output.py
@@ -1,6 +1,6 @@
 import re
 import os
-from distutils.spawn import find_executable
+from shutil import which
 
 from ..exceptions import PyCallGraphException
 from ..color import Color
@@ -90,7 +90,7 @@ class Output(object):
         raise NotImplementedError('done')
 
     def ensure_binary(self, cmd):
-        if find_executable(cmd):
+        if which(cmd):
             return
 
         raise PyCallGraphException(

--- a/pycallgraph/tracer.py
+++ b/pycallgraph/tracer.py
@@ -2,8 +2,8 @@
 
 import inspect
 import sys
+import sysconfig
 import time
-from distutils import sysconfig
 from collections import defaultdict
 from threading import Thread
 try:
@@ -104,7 +104,7 @@ class TraceProcessor(Thread):
 
     def init_libpath(self):
         self.lib_paths = [
-            sysconfig.get_python_lib(standard_lib=True).lower(),
+            sysconfig.get_path('purelib').lower(),
             sysconfig.get_config_var('LIBDEST').lower(),
         ]
 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,4 @@
-pytest==6.1.2
-pytest-cov==2.12.1
+pytest==8.1.1
+pytest-cov==5.0.0
 python-coveralls==2.9.3
-flake8==3.9.2
+flake8==7.0.0


### PR DESCRIPTION
No idea how CI passed or if this is just low-coverage, but python 3.12 locally failed when doing a manual run-through

This is the result of fixing errors, which mostly came from deprecation of `distutils` in 3.12