### PR TITLE
ci: auto-generate docs

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,39 @@
+name: documentation
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Install dependencies
+        run: |
+          pip install -r requirements/development.txt
+          pip install -r requirements/documentation.txt
+      - name: Sphinx build
+        run: make clean && make doc
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+      - name: Deploy to GitHub Pages (branch)
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html
+          destination_dir: branch/${{ steps.extract_branch.outputs.branch }}
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html
+          destination_dir: /

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -2,6 +2,10 @@ name: documentation
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
Following the following guides

- https://coderefinery.github.io/documentation/gh_workflow/
- https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-deploy-to-subdirectory-destination_dir

This hopes to publish a github pages branch for every PR and on merge.

Upon merge the github pages site should be updated
Upon PR the github pages build should be available at `{baseUrl}/branch/{branchName}`

~This is publishing the branch docs. But they are as-yet, not showing in github pages.~

https://lewiscowles1986.github.io/py-call-graph/branch/ci/auto-generate-docs/

Going to merge to `main` to test that having root docs updates.