### PR TITLE
docs: examples-fix-attempt

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -47,3 +47,16 @@ jobs:
           publish_dir: docs/_build/html
           destination_dir: ./
           keep_files: true
+      - name: Create files for redeploy
+        run: |
+          rm -rf tmp/bump
+          mkdir -p tmp/bump
+          echo $(date +"%Y-%m-%dT%H%M%S") > tmp/bump/last_deploy
+      - name: Force redeploy of GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: tmp/bump
+          destination_dir: ./
+          keep_files: true

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ The uploader makes no representations of their contribution, and merely wanted t
 
 Click on the images below to see a larger version and the source code that generated them.
 
-[![Basic Output thumbnail](http://pycallgraph.readthedocs.io/en/develop/_images/basic_thumb.png)](http://pycallgraph.readthedocs.io/en/develop/examples/basic.html)
+[![Basic Output thumbnail](https://lewiscowles1986.github.io/py-call-graph/_images/basic_thumb.png)](https://lewiscowles1986.github.io/py-call-graph/examples/basic.html)
 
-[![Regex grouped Output thumbnail](https://pycallgraph.readthedocs.io/en/develop/_images/regexp_grouped_thumb.png)](https://pycallgraph.readthedocs.io/en/develop/examples/regexp_grouped.html)
+[![Regex grouped Output thumbnail](https://lewiscowles1986.github.io/py-call-graph/_images/regexp_grouped_thumb.png)](https://lewiscowles1986.github.io/py-call-graph/examples/regexp_grouped)
 
-[![Regex ungrouped Output thumbnail](https://pycallgraph.readthedocs.io/en/develop/_images/regexp_ungrouped_thumb.png)](https://pycallgraph.readthedocs.io/en/develop/examples/regexp_ungrouped.html)
+[![Regex ungrouped Output thumbnail](https://lewiscowles1986.github.io/py-call-graph/_images/regexp_ungrouped_thumb.png)](https://lewiscowles1986.github.io/py-call-graph/examples/regexp_ungrouped.html)
 
 ## Project Status
 


### PR DESCRIPTION
it looks like the last merge took out examples... FFS this is flakey

This is just like the WordPress github action to deploy to SVN; it cares deeply about `.gitignore`

https://lewiscowles1986.github.io/py-call-graph/branch/docs/examples-fix-attempt/examples/regexp_ungrouped.html