### PR TITLE
fix: do not keep module without __file__

### DIFF
--- a/pycallgraph/tracer.py
+++ b/pycallgraph/tracer.py
@@ -166,10 +166,13 @@ class TraceProcessor(Thread):
             module = inspect.getmodule(code)
             if module:
                 module_name = module.__name__
-                module_path = module.__file__
+                try:
+                    module_path = module.__file__
 
-                if not self.config.include_stdlib \
-                        and self.is_module_stdlib(module_path):
+                    if not self.config.include_stdlib \
+                            and self.is_module_stdlib(module_path):
+                        keep = False
+                except AttributeError:
                     keep = False
 
                 if module_name == '__main__':


### PR DESCRIPTION
Some modules don't have a `__file__` field which caused crash when importing them when profiling.

Do not keep these modules to avoid crashing when importing them.

There is no impact on modules which have a `__file__` field.

Fix #30 