### PR TITLE
fix: supply argparse with REMAINDER not ZERO_OR_MORE

### DIFF
--- a/pycallgraph/config.py
+++ b/pycallgraph/config.py
@@ -110,7 +110,7 @@ class Config(object):
             help='The Python script file to profile',
         )
         parent_parser.add_argument(
-            'command_args', metavar='ARG', nargs='*',
+            'command_args', metavar='ARG', nargs=argparse.REMAINDER,
             help='Python script arguments.'
         )
         return parent_parser


### PR DESCRIPTION
in python 3.12 I experienced the graphviz subparser of argparse not receiving arguments.

I looked to see if `-1` was supplied, which was a formerly undocumented use.

If I'm honest, this just feels like the python people dont have enough tests in argparse.

It could be that just some releases of 3.12 have this bug, but as this fixes the bug in that version, I'd like to see if our test-suite catches anything, or if this is good enough for now.